### PR TITLE
add require etc

### DIFF
--- a/lib/wp2txt.rb
+++ b/lib/wp2txt.rb
@@ -11,6 +11,7 @@ require "wp2txt/article"
 require "wp2txt/utils"
 require "wp2txt/progressbar"
 # require "wp2txt/mw_api"
+require 'etc'
 
 begin
   require "bzip2-ruby"


### PR DESCRIPTION
My ruby environment `Ruby 3.1.2`, following error occured: 

```
/usr/local/rvm/gems/ruby-3.1.2/gems/wp2txt-0.9.1/lib/wp2txt.rb:37:in `initialize': uninitialized constant Wp2txt::Runner::Etc (NameError)

      num_cores_available = Etc.nprocessors\r
                            ^^^
        from /usr/local/rvm/gems/ruby-3.1.2/gems/wp2txt-0.9.1/bin/wp2txt:63:in `new'
        from /usr/local/rvm/gems/ruby-3.1.2/gems/wp2txt-0.9.1/bin/wp2txt:63:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-3.1.2/bin/wp2txt:25:in `load'
        from /usr/local/rvm/gems/ruby-3.1.2/bin/wp2txt:25:in `<main>'
        from /usr/local/rvm/gems/ruby-3.1.2/bin/ruby_executable_hooks:22:in `eval'
        from /usr/local/rvm/gems/ruby-3.1.2/bin/ruby_executable_hooks:22:in `<main>'
```

This PR fix this.